### PR TITLE
PACT-381 - EPR - Rendering Edit Set from model

### DIFF
--- a/app/uk/gov/nationalarchives/omega/editorial/controllers/EditSetController.scala
+++ b/app/uk/gov/nationalarchives/omega/editorial/controllers/EditSetController.scala
@@ -27,12 +27,13 @@ import play.api.i18n.Messages
 import play.api.mvc._
 import play.api.Logger
 import uk.gov.nationalarchives.omega.editorial._
+import uk.gov.nationalarchives.omega.editorial.models.{ EditSet, EditSetEntry }
 
 /** This controller creates an `Action` to handle HTTP requests to the
   * application's home page.
   */
 @Singleton
-class EditSetController @Inject() (val messagesControllerComponents: MessagesControllerComponents)
+class EditSetController @Inject()(val messagesControllerComponents: MessagesControllerComponents)
     extends MessagesAbstractController(messagesControllerComponents) {
 
   val logger: Logger = Logger(this.getClass())
@@ -45,10 +46,27 @@ class EditSetController @Inject() (val messagesControllerComponents: MessagesCon
     */
   def view(id: String) = Action { implicit request: Request[AnyContent] =>
     logger.info(s"The edit set id is $id ")
+    val editSet = getEditSet(id)
     val messages: Messages = request.messages
     val title: String = messages("edit-set.title")
-    val heading: String = messages("edit-set.heading")
-    Ok(views.html.editSet(title, heading))
+    val heading: String = messages("edit-set.heading", editSet.name)
+    Ok(views.html.editSet(title, heading, editSet))
+  }
+
+  def getEditSet(id: String): EditSet = {
+
+    val scopeAndContent = "Bedlington Colliery, Newcastle Upon Tyne. Photograph depicting: view of pithead baths."
+    val editSetEntry1 =
+      EditSetEntry("COAL 80/80/1", id, scopeAndContent, "1960")
+    val editSetEntry2 =
+      EditSetEntry("COAL 80/80/2", id, scopeAndContent, "1960")
+    val editSetEntry3 =
+      EditSetEntry("COAL 80/80/3", id, scopeAndContent, "1960")
+    val entries = Seq(editSetEntry1, editSetEntry2, editSetEntry3)
+    val editSetName = "COAL 80 Sample"
+    val editSet = EditSet(editSetName, id: String, entries)
+
+    editSet
   }
 
   /** Create an Action for the edit set record edit page.

--- a/app/uk/gov/nationalarchives/omega/editorial/controllers/EditSetController.scala
+++ b/app/uk/gov/nationalarchives/omega/editorial/controllers/EditSetController.scala
@@ -33,7 +33,7 @@ import uk.gov.nationalarchives.omega.editorial.models.{ EditSet, EditSetEntry }
   * application's home page.
   */
 @Singleton
-class EditSetController @Inject()(val messagesControllerComponents: MessagesControllerComponents)
+class EditSetController @Inject() (val messagesControllerComponents: MessagesControllerComponents)
     extends MessagesAbstractController(messagesControllerComponents) {
 
   val logger: Logger = Logger(this.getClass())
@@ -64,9 +64,7 @@ class EditSetController @Inject()(val messagesControllerComponents: MessagesCont
       EditSetEntry("COAL 80/80/3", id, scopeAndContent, "1960")
     val entries = Seq(editSetEntry1, editSetEntry2, editSetEntry3)
     val editSetName = "COAL 80 Sample"
-    val editSet = EditSet(editSetName, id: String, entries)
-
-    editSet
+    EditSet(editSetName, id: String, entries)
   }
 
   /** Create an Action for the edit set record edit page.

--- a/app/uk/gov/nationalarchives/omega/editorial/views/editSet.scala.html
+++ b/app/uk/gov/nationalarchives/omega/editorial/views/editSet.scala.html
@@ -1,5 +1,26 @@
-@(title: String, heading: String)
+@import uk.gov.nationalarchives.omega.editorial.models.{ EditSet, EditSetEntry }
+
+@(title: String, heading: String, editSet: EditSet)
 
 @template(title) {
   <h1>@heading</h1>
+
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">CCR</th>
+      <th scope="col" class="govuk-table__header">Scope and Content</th>
+      <th scope="col" class="govuk-table__header">Covering Dates</th>
+    </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    @for(entry <- editSet.entries) {
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">@entry.ccr</td>
+      <td class="govuk-table__cell">@entry.scopeAndContent</td>
+      <td class="govuk-table__cell">@entry.coveringDates</td>
+    </tr>
+    }
+    </tbody>
+  </table>
 }

--- a/app/uk/gov/nationalarchives/omega/editorial/views/editSet.scala.html
+++ b/app/uk/gov/nationalarchives/omega/editorial/views/editSet.scala.html
@@ -4,7 +4,7 @@
 
 @template(title) {
  <table class="govuk-table">
-    <caption class="govuk-table__caption govuk-table__caption--l">@heading</caption>
+    <caption class="govuk-table__caption govuk-table__caption--m">@heading</caption>
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">CCR</th>

--- a/app/uk/gov/nationalarchives/omega/editorial/views/editSet.scala.html
+++ b/app/uk/gov/nationalarchives/omega/editorial/views/editSet.scala.html
@@ -3,9 +3,8 @@
 @(title: String, heading: String, editSet: EditSet)
 
 @template(title) {
-  <h1>@heading</h1>
-
-  <table class="govuk-table">
+ <table class="govuk-table">
+    <caption class="govuk-table__caption govuk-table__caption--l">@heading</caption>
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">CCR</th>

--- a/conf/messages
+++ b/conf/messages
@@ -10,6 +10,6 @@ login.missing.username=Enter a username
 login.missing.password=Enter a password
 login.authentication.error=Username and/or password is incorrect.
 edit-set.title=Edit set
-edit-set.heading=Edit set: COAL 80 Sample
+edit-set.heading=Edit set: {0}
 edit-set.record.edit.title=Edit record
 edit-set.record.edit.heading=TNA reference: COAL 80/80/1

--- a/test/views/EditSetViewSpec.scala
+++ b/test/views/EditSetViewSpec.scala
@@ -26,19 +26,45 @@ import play.api.test.Helpers.{ contentAsString, defaultAwaitTimeout }
 import play.test.WithApplication
 import play.twirl.api.Html
 import uk.gov.nationalarchives.omega.editorial._
+import uk.gov.nationalarchives.omega.editorial.models.{ EditSet, EditSetEntry }
+import uk.gov.nationalarchives.omega.editorial.views.html.editSet
 
 class EditSetViewSpec extends PlaySpec {
 
   "Edit set Html" should {
     "render the given title and heading" in new WithApplication {
+
+      val editSet: EditSet = getEditSetTest("1")
       val title = "EditSetTitleTest"
-      val heading = "EditSetHeadingTest"
+      val heading = editSet.name
 
-      val editSetHtml: Html = views.html.editSet(title, heading)
-
+      val editSetHtml: Html = views.html.editSet(title, heading, editSet)
       contentAsString(editSetHtml) must include(title)
       contentAsString(editSetHtml) must include(heading)
+      contentAsString(editSetHtml) must include(editSet.name)
+      for (entry <- editSet.entries) {
+        contentAsString(editSetHtml) must include(entry.ccr)
+        contentAsString(editSetHtml) must include(entry.scopeAndContent)
+        contentAsString(editSetHtml) must include(entry.coveringDates)
+
+      }
+
     }
 
+    def getEditSetTest(id: String): EditSet = {
+
+      val scopeAndContent = "Bedlington Colliery, Newcastle Upon Tyne. Photograph depicting: view of pithead baths."
+      val editSetEntry1 =
+        EditSetEntry("COAL 80/80/1", id, scopeAndContent, "1960")
+      val editSetEntry2 =
+        EditSetEntry("COAL 80/80/2", id, scopeAndContent, "1960")
+      val editSetEntry3 =
+        EditSetEntry("COAL 80/80/3", id, scopeAndContent, "1960")
+      val entries = Seq(editSetEntry1, editSetEntry2, editSetEntry3)
+      val editSetName = "COAL 80 Sample"
+      val editSet = EditSet(editSetName, id: String, entries)
+
+      editSet
+    }
   }
 }


### PR DESCRIPTION
The Edit Set page now renders a table according to GDS components that takes a EntrySet model object and creates a row in the table iteratively from a sequence of EntrySetEntry objects.

Also the heading of the page is now created from a parametrized message along with the Entry Set name.