### PR TITLE
Add an RPM build to scala.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ lazy val root = Project("ctd-omega-editorial-frontend", file("."))
   .enablePlugins(PlayScala)
   .enablePlugins(BuildInfoPlugin)
   .enablePlugins(AutomateHeaderPlugin)
+  .enablePlugins(RpmPlugin)
   .settings(
     Defaults.itSettings,
     organization := "uk.gov.nationalarchives",
@@ -108,7 +109,10 @@ lazy val root = Project("ctd-omega-editorial-frontend", file("."))
       "org.webjars.npm" % "govuk-frontend" % "4.3.1",
       "uk.gov.hmrc" %% "play-frontend-hmrc" % "3.30.0-play-28",
       "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test
-    )
+    ),
+
+    rpmVendor := "nationalarchives.gov.uk",
+    rpmLicense := Some("MIT")
   )
 // Adds additional packages into Twirl
 //TwirlKeys.templateImports += "uk.gov.nationalarchives.controllers._"


### PR DESCRIPTION
I would like us to build an RPM from running: `Rpm / packageBin`

However at the moment this does not work due to UTF-8 encoding issues When running `Rpm / packageBin` you get the errors:

```
[error] error: Package ctd-omega-editorial-frontend: invalid utf-8 encoding in Classdict: TrueType Font data, digitally signed, 19 tables, 1st "DSIG", 26 names, Macintosh, Digitized data copyright � 2010-2011, Google Corporation.Open SansItalic1.10;1ASC;OpenSans-Itali - Illegal byte sequence
[error] error: Package ctd-omega-editorial-frontend: invalid utf-8 encoding in Classdict: TrueType Font data, digitally signed, 19 tables, 1st "DSIG", 26 names, Macintosh, Digitized data copyright � 2010-2011, Google Corporation.Open SansBold1.10;1ASC;OpenSans-BoldOpe - Illegal byte sequence
[error] error: Package ctd-omega-editorial-frontend: invalid utf-8 encoding in Classdict: TrueType Font data, digitally signed, 19 tables, 1st "DSIG", 26 names, Macintosh, Digitized data copyright � 2010-2011, Google Corporation.Open SansBold Italic1.10;1ASC;OpenSans- - Illegal byte sequence
[error]     absolute symlink: /etc/ctd-omega-editorial-frontend -> /usr/share/ctd-omega-editorial-frontend/conf
[error]     absolute symlink: /usr/bin/ctd-omega-editorial-frontend -> /usr/share/ctd-omega-editorial-frontend/bin/ctd-omega-editorial-frontend
[error]     absolute symlink: /usr/share/ctd-omega-editorial-frontend/logs -> /var/log/ctd-omega-editorial-frontend
[error]     Package ctd-omega-editorial-frontend: invalid utf-8 encoding in Classdict: TrueType Font data, digitally signed, 19 tables, 1st "DSIG", 26 names, Macintosh, Digitized data copyright � 2010-2011, Google Corporation.Open SansItalic1.10;1ASC;OpenSans-Itali - Illegal byte sequence
[error]     Package ctd-omega-editorial-frontend: invalid utf-8 encoding in Classdict: TrueType Font data, digitally signed, 19 tables, 1st "DSIG", 26 names, Macintosh, Digitized data copyright � 2010-2011, Google Corporation.Open SansBold1.10;1ASC;OpenSans-BoldOpe - Illegal byte sequence
[error]     Package ctd-omega-editorial-frontend: invalid utf-8 encoding in Classdict: TrueType Font data, digitally signed, 19 tables, 1st "DSIG", 26 names, Macintosh, Digitized data copyright � 2010-2011, Google Corporation.Open SansBold Italic1.10;1ASC;OpenSans- - Illegal byte sequence
[error] RPM build errors:
[error] stack trace is suppressed; run last Rpm / packageBin for the full output
[error] (Rpm / packageBin) Unable to run rpmbuild, check output for details. Errorcode 1
```

See related information:
1. https://www.playframework.com/documentation/2.8.x/Deploying#Minimal-RPM-settings
2. https://github.com/rpm-software-management/rpm/issues/952
3. https://bugzilla.redhat.com/show_bug.cgi?id=1876946