### PR TITLE
PACT-446 | EPR | Creation of navigation links

### DIFF
--- a/app/uk/gov/nationalarchives/omega/editorial/views/editSet.scala.html
+++ b/app/uk/gov/nationalarchives/omega/editorial/views/editSet.scala.html
@@ -29,7 +29,7 @@
 
 @recordLink(ccr: String, oci: String) = {
     @defining("/edit-set/1/record/"+oci+"/edit") { hrefLink =>
-        <a href=@hrefLink>@ccr</a>
+        <a class="govuk-link govuk-link--no-visited-state" href=@hrefLink>@ccr</a>
     }
 }
 
@@ -63,6 +63,7 @@
           )
       ),
       caption = Some(heading) ,
-    captionClasses = "govuk-table__caption--m",
+      captionClasses = "govuk-table__caption--m",
+      firstCellIsHeader = true
   ))
 }


### PR DESCRIPTION
govuk-link class added to hyperlinks. Table first cell is now set to be a heading cell.