### PR TITLE
PACT-575 Investigate existing options for ordering of columns in lists of results in the Web Application

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -26,3 +26,70 @@
 .govuk-width-container {
     max-width: 70em;
 }
+
+[aria-sort] button,
+[aria-sort] button:hover {
+  background-color: transparent;
+  border-width: 0;
+  -webkit-box-shadow: 0 0 0 0;
+  -moz-box-shadow: 0 0 0 0;
+  box-shadow: 0 0 0 0;
+  color: #005ea5;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  padding: 0 10px 0 0;
+  position: relative;
+  text-align: inherit;
+  font-size: 1em;
+  margin: 0;
+}
+
+[aria-sort] button:focus {
+  background-color: $govuk-focus-colour;
+  color: $govuk-focus-text-colour;
+  box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
+  outline: none;
+}
+
+[aria-sort]:first-child button {
+  right: auto;
+}
+
+[aria-sort] button:before {
+  content: " \25bc";
+  position: absolute;
+  right: -1px;
+  top: 9px;
+  font-size: 0.5em;
+}
+
+[aria-sort] button:after {
+  content: " \25b2";
+  position: absolute;
+  right: -1px;
+  top: 1px;
+  font-size: 0.5em;
+}
+
+[aria-sort="ascending"] button:before,
+[aria-sort="descending"] button:before {
+  content: none;
+}
+
+[aria-sort="ascending"] button:after {
+  content: " \25b2";
+  font-size: .8em;
+  position: absolute;
+  right: -5px;
+  top: 2px;
+}
+
+[aria-sort="descending"] button:after {
+  content: " \25bc";
+  font-size: .8em;
+  position: absolute;
+  right: -5px;
+  top: 2px;
+}

--- a/app/uk/gov/nationalarchives/omega/editorial/controllers/TableDemoController.scala
+++ b/app/uk/gov/nationalarchives/omega/editorial/controllers/TableDemoController.scala
@@ -55,11 +55,18 @@ class TableDemoController @Inject() (
   }
 
   def sortedTable(): Action[AnyContent] = Action { implicit request: Request[AnyContent] =>
-    println(request.body.asFormUrlEncoded)
-    val headerName = request.body.asFormUrlEncoded.get("action").head
-    val sortedTableValues = tableValues.changeOrdering(headerName).get
-    tableValues = sortedTableValues
-    Ok(tableDemo(sortedTableValues))
+    val action = for {
+      headerName <- request.body.asFormUrlEncoded.get("action").headOption
+      sortedTableValues <- tableValues.changeOrdering(headerName)
+    } yield sortedTableValues
+
+    action match {
+      case Some(sortedTableValues) =>
+        tableValues = sortedTableValues
+        Ok(tableDemo(sortedTableValues))
+      case None =>
+        BadRequest("missing or unrecognised action or bad table header to sort")
+    }
   }
 
 }

--- a/app/uk/gov/nationalarchives/omega/editorial/controllers/TableDemoController.scala
+++ b/app/uk/gov/nationalarchives/omega/editorial/controllers/TableDemoController.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 The National Archives
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.gov.nationalarchives.omega.editorial.controllers
+
+import javax.inject._
+import play.api.i18n._
+import play.api.mvc._
+import play.api.data._
+import uk.gov.nationalarchives.omega.editorial.views.html.tableDemo
+import uk.gov.nationalarchives.omega.editorial.models.TableValues
+
+/** This controller creates an `Action` to handle HTTP requests to the application's home page.
+  */
+@Singleton
+class TableDemoController @Inject() (
+  val messagesControllerComponents: MessagesControllerComponents,
+  tableDemo: tableDemo
+) extends MessagesAbstractController(messagesControllerComponents) with I18nSupport {
+
+  var tableValues = TableValues(
+    headers = List("Name", "Elevation", "Continent", "First Summit"),
+    rows = List(
+      List("Test2", "6,962 meters", "South America", "1897"),
+      List("Aconcagua", "6,961 meters", "South America", "1897"),
+      List("Denali", "6,194 meters", "North America", "1913"),
+      List("Elbrus", "5,642 meters", "Europe", "1874"),
+      List("Everest", "8,850 meters", "Asia", "1953"),
+      List("Kilimanjaro", "5,895 meters", "Africa", "1889"),
+      List("Puncak Jaya", "4,884 meters", "Australia", "1962"),
+      List("Vinson", "4,897 meters", "Antarctica", "1966")
+    )
+  )
+
+  def table(): Action[AnyContent] = Action { implicit request: Request[AnyContent] =>
+    Ok(tableDemo(tableValues))
+  }
+
+  def sortedTable(): Action[AnyContent] = Action { implicit request: Request[AnyContent] =>
+    println(request.body.asFormUrlEncoded)
+    val headerName = request.body.asFormUrlEncoded.get("action").head
+    val sortedTableValues = tableValues.changeOrdering(headerName).get
+    tableValues = sortedTableValues
+    Ok(tableDemo(sortedTableValues))
+  }
+
+}
+

--- a/app/uk/gov/nationalarchives/omega/editorial/models/TableValues.scala
+++ b/app/uk/gov/nationalarchives/omega/editorial/models/TableValues.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022 The National Archives
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.gov.nationalarchives.omega.editorial.models
+
+sealed abstract class CellOrdering
+object CellOrdering {
+  case class Ascending(value: String) extends CellOrdering
+  case class Descending(value: String) extends CellOrdering
+  case object None extends CellOrdering
+}
+
+case class TableValues(
+  headers: List[String],
+  rows: List[List[String]],
+  orderedBy: CellOrdering = CellOrdering.None
+) {
+
+  def orderingNameForHeader(name: String): String =
+    orderedBy match {
+      case CellOrdering.Ascending(value) if name == value  => "ascending"
+      case CellOrdering.Descending(value) if name == value => "descending"
+      case _                                               => "none"
+    }
+
+  def changeOrdering(name: String): Option[TableValues] =
+    headers.indexOf(name) match {
+      case -1 => None
+      case index =>
+        Some(
+          orderedBy match {
+            case CellOrdering.Ascending(orderHeader) if orderHeader == name =>
+              this.copy(
+                rows = rows.sortBy(xs => xs(index)).reverse,
+                orderedBy = CellOrdering.Descending(orderHeader)
+              )
+            case CellOrdering.Descending(orderHeader) if orderHeader == name =>
+              this.copy(
+                rows = rows.sortBy(xs => xs(index)),
+                orderedBy = CellOrdering.Ascending(orderHeader)
+              )
+            case _ =>
+              this.copy(
+                rows = rows.sortBy(xs => xs(index)),
+                orderedBy = CellOrdering.Ascending(name)
+              )
+          }
+        )
+    }
+
+}

--- a/app/uk/gov/nationalarchives/omega/editorial/views/editSetRecordEdit.scala.html
+++ b/app/uk/gov/nationalarchives/omega/editorial/views/editSetRecordEdit.scala.html
@@ -97,7 +97,7 @@
 }
 
 @dateSelector(prefix: String, labelKey: String) = {
-    <label class="govuk-label govuk-label--s">
+    <label class="govuk-label">
     @messages(labelKey)
     </label>
 @editSetRecordForm.error(prefix + "DateDay").map { error =>
@@ -143,11 +143,7 @@
     id = "scopeAndContent",
     name = "scopeAndContent",
     value = editSetRecordForm.data.get("scopeAndContent"),
-    label = Label(
-      forAttr = Some("scopeAndContent"),
-      content = Text(messages("edit-set.record.edit.scope-and-content")),
-      classes = "govuk-label--s"
-    ),
+    label = Label(forAttr = Some("scopeAndContent"), content = Text(messages("edit-set.record.edit.scope-and-content"))),
     errorMessage = editSetRecordForm.error("scopeAndContent").map { error =>
         ErrorMessage(
             content = Text(error.message),
@@ -159,11 +155,7 @@
     id = "formerReferenceDepartment",
     name = "formerReferenceDepartment",
     value = editSetRecordForm.data.get("formerReferenceDepartment"),
-    label = Label(
-      forAttr = Some("formerReferenceDepartment"),
-      content = Text(messages("edit-set.record.edit.former-reference")),
-      classes = "govuk-label--s"
-    ),
+    label = Label(forAttr = Some("formerReferenceDepartment"), content = Text(messages("edit-set.record.edit.former-reference"))),
     errorMessage = editSetRecordForm.error("formerReferenceDepartment").map { error =>
         ErrorMessage(
             content = Text(error.message),
@@ -176,11 +168,7 @@
     name = "coveringDates",
     attributes = Map(),
     value = editSetRecordForm.data.get("coveringDates"),
-    label = Label(
-      forAttr = Some("coveringDates"),
-      content = Text(messages("edit-set.record.edit.covering-dates")),
-      classes = "govuk-label--s"
-    ),
+    label = Label(forAttr = Some("coveringDates"), content = Text(messages("edit-set.record.edit.covering-dates"))),
     errorMessage = editSetRecordForm.error("coveringDates").map { error =>
         ErrorMessage(
             content = Text(error.message),
@@ -217,11 +205,7 @@
             value = Some(status.uri)
         )
     },
-    label = Label(
-      forAttr = Some("legalStatus"),
-      content = Text(messages("edit-set.record.edit.legal-status")),
-      classes = "govuk-label--s"
-    ),
+    label = Label(forAttr = Some("legalStatus"), content = Text(messages("edit-set.record.edit.legal-status"))),
     errorMessage = editSetRecordForm.error("legalStatus").map { error =>
         ErrorMessage(
             content = Text(error.message),
@@ -262,11 +246,7 @@
             )
         }.toSeq
     },
-    label = Label(
-      forAttr = Some("placeOfDeposit"),
-      content = Text(messages("edit-set.record.edit.place-of-deposit")),
-      classes = "govuk-label--s"
-    ),
+    label = Label(forAttr = Some("placeOfDeposit"), content = Text(messages("edit-set.record.edit.place-of-deposit"))),
     errorMessage = editSetRecordForm.error("placeOfDeposit").map { error =>
         ErrorMessage(
             content = Text(error.message),
@@ -279,11 +259,7 @@
     id = "note",
     name = "note",
     value = editSetRecordForm.data.get("note"),
-    label = Label(
-      forAttr = Some("note"),
-      content = Text(messages("edit-set.record.edit.note")),
-      classes = "govuk-label--s"
-    ),
+    label = Label(forAttr = Some("note"), content = Text(messages("edit-set.record.edit.note"))),
     errorMessage = editSetRecordForm.error("note").map { error =>
         ErrorMessage(
             content = Text(error.message),

--- a/app/uk/gov/nationalarchives/omega/editorial/views/editSetRecordEdit.scala.html
+++ b/app/uk/gov/nationalarchives/omega/editorial/views/editSetRecordEdit.scala.html
@@ -97,7 +97,7 @@
 }
 
 @dateSelector(prefix: String, labelKey: String) = {
-    <label class="govuk-label">
+    <label class="govuk-label govuk-label--s">
     @messages(labelKey)
     </label>
 @editSetRecordForm.error(prefix + "DateDay").map { error =>
@@ -143,7 +143,11 @@
     id = "scopeAndContent",
     name = "scopeAndContent",
     value = editSetRecordForm.data.get("scopeAndContent"),
-    label = Label(forAttr = Some("scopeAndContent"), content = Text(messages("edit-set.record.edit.scope-and-content"))),
+    label = Label(
+      forAttr = Some("scopeAndContent"),
+      content = Text(messages("edit-set.record.edit.scope-and-content")),
+      classes = "govuk-label--s"
+    ),
     errorMessage = editSetRecordForm.error("scopeAndContent").map { error =>
         ErrorMessage(
             content = Text(error.message),
@@ -155,7 +159,11 @@
     id = "formerReferenceDepartment",
     name = "formerReferenceDepartment",
     value = editSetRecordForm.data.get("formerReferenceDepartment"),
-    label = Label(forAttr = Some("formerReferenceDepartment"), content = Text(messages("edit-set.record.edit.former-reference"))),
+    label = Label(
+      forAttr = Some("formerReferenceDepartment"),
+      content = Text(messages("edit-set.record.edit.former-reference")),
+      classes = "govuk-label--s"
+    ),
     errorMessage = editSetRecordForm.error("formerReferenceDepartment").map { error =>
         ErrorMessage(
             content = Text(error.message),
@@ -168,7 +176,11 @@
     name = "coveringDates",
     attributes = Map(),
     value = editSetRecordForm.data.get("coveringDates"),
-    label = Label(forAttr = Some("coveringDates"), content = Text(messages("edit-set.record.edit.covering-dates"))),
+    label = Label(
+      forAttr = Some("coveringDates"),
+      content = Text(messages("edit-set.record.edit.covering-dates")),
+      classes = "govuk-label--s"
+    ),
     errorMessage = editSetRecordForm.error("coveringDates").map { error =>
         ErrorMessage(
             content = Text(error.message),
@@ -205,7 +217,11 @@
             value = Some(status.uri)
         )
     },
-    label = Label(forAttr = Some("legalStatus"), content = Text(messages("edit-set.record.edit.legal-status"))),
+    label = Label(
+      forAttr = Some("legalStatus"),
+      content = Text(messages("edit-set.record.edit.legal-status")),
+      classes = "govuk-label--s"
+    ),
     errorMessage = editSetRecordForm.error("legalStatus").map { error =>
         ErrorMessage(
             content = Text(error.message),
@@ -246,7 +262,11 @@
             )
         }.toSeq
     },
-    label = Label(forAttr = Some("placeOfDeposit"), content = Text(messages("edit-set.record.edit.place-of-deposit"))),
+    label = Label(
+      forAttr = Some("placeOfDeposit"),
+      content = Text(messages("edit-set.record.edit.place-of-deposit")),
+      classes = "govuk-label--s"
+    ),
     errorMessage = editSetRecordForm.error("placeOfDeposit").map { error =>
         ErrorMessage(
             content = Text(error.message),
@@ -259,7 +279,11 @@
     id = "note",
     name = "note",
     value = editSetRecordForm.data.get("note"),
-    label = Label(forAttr = Some("note"), content = Text(messages("edit-set.record.edit.note"))),
+    label = Label(
+      forAttr = Some("note"),
+      content = Text(messages("edit-set.record.edit.note")),
+      classes = "govuk-label--s"
+    ),
     errorMessage = editSetRecordForm.error("note").map { error =>
         ErrorMessage(
             content = Text(error.message),

--- a/app/uk/gov/nationalarchives/omega/editorial/views/tableDemo.scala.html
+++ b/app/uk/gov/nationalarchives/omega/editorial/views/tableDemo.scala.html
@@ -1,0 +1,62 @@
+@*
+ * Copyright (c) 2022 The National Archives
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *@
+
+@import uk.gov.nationalarchives.omega.editorial.models.TableValues
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
+@import views.html.helper.CSRF
+@import uk.gov.nationalarchives.omega.editorial.controllers.EditSetController.EditSetReorder
+
+@this(govukTable: GovukTable, govukButton: GovukButton, govukFieldset: GovukFieldset, govukLabel: GovukLabel)
+
+@(values: TableValues, lastSort: Option[String] = None)(implicit messages: Messages, request: Request[AnyContent])
+
+@headerSubmitButton(value: String) = {
+  <button name="action" value="@value">@value</button>
+}
+
+@template(None, "title here") {
+
+<form method="POST" action="/sortedTable">
+  @CSRF.formField
+  @govukTable(Table(
+      head = Some(
+        values.headers.map { headerCell =>
+          HeadCell(
+            content = HtmlContent(headerSubmitButton(headerCell)),
+            attributes = Map("aria-sort" -> values.orderingNameForHeader(headerCell))
+          )
+        }
+      ),
+      rows = values.rows.map { row =>
+        row.map { cell =>
+          TableRow(
+            content = Text(cell)
+          )
+        }
+      },
+      caption = Some("Table Demo"),
+      captionClasses = "govuk-table__caption--m"
+  ))
+
+</form>
+
+}

--- a/app/uk/gov/nationalarchives/omega/editorial/views/tableDemo.scala.html
+++ b/app/uk/gov/nationalarchives/omega/editorial/views/tableDemo.scala.html
@@ -26,7 +26,7 @@
 
 @this(govukTable: GovukTable)
 
-@(values: TableValues )(implicit messages: Messages, request: Request[AnyContent])
+@(values: TableValues)(implicit messages: Messages, request: Request[AnyContent])
 
 @headerSubmitButton(value: String) = {
   <button name="action" value="@value">@value</button>

--- a/app/uk/gov/nationalarchives/omega/editorial/views/tableDemo.scala.html
+++ b/app/uk/gov/nationalarchives/omega/editorial/views/tableDemo.scala.html
@@ -23,19 +23,18 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
 @import views.html.helper.CSRF
-@import uk.gov.nationalarchives.omega.editorial.controllers.EditSetController.EditSetReorder
 
-@this(govukTable: GovukTable, govukButton: GovukButton, govukFieldset: GovukFieldset, govukLabel: GovukLabel)
+@this(govukTable: GovukTable)
 
-@(values: TableValues, lastSort: Option[String] = None)(implicit messages: Messages, request: Request[AnyContent])
+@(values: TableValues )(implicit messages: Messages, request: Request[AnyContent])
 
 @headerSubmitButton(value: String) = {
   <button name="action" value="@value">@value</button>
 }
 
-@template(None, "title here") {
+@template(None, "Table Demo") {
 
-<form method="POST" action="/sortedTable">
+<form method="POST" action="@uk.gov.nationalarchives.omega.editorial.controllers.routes.TableDemoController.sortedTable()">
   @CSRF.formField
   @govukTable(Table(
       head = Some(
@@ -56,7 +55,6 @@
       caption = Some("Table Demo"),
       captionClasses = "govuk-table__caption--m"
   ))
-
 </form>
 
 }

--- a/conf/routes
+++ b/conf/routes
@@ -15,6 +15,8 @@ POST        /edit-set/:id/record/:recordId/edit                uk.gov.nationalar
 GET         /edit-set/:id/record/:recordId/edit/save           uk.gov.nationalarchives.omega.editorial.controllers.EditSetController.save(id: String, recordId: String)
 GET         /edit-set/:id/record/:recordId/edit/discard        uk.gov.nationalarchives.omega.editorial.controllers.EditSetController.discard(id: String, recordId: String)
 
+GET         /table                                             uk.gov.nationalarchives.omega.editorial.controllers.TableDemoController.table()
+POST        /table                                             uk.gov.nationalarchives.omega.editorial.controllers.TableDemoController.sortedTable()
 
 # Map static resources from the /public folder to the /assets URL path
 GET         /assets/*file                                      controllers.Assets.versioned(path="/public", file: Asset)


### PR DESCRIPTION
Table on page load, note that none of the table headers indicate a sort:
![Screenshot 2023-01-18 at 09 52 28](https://user-images.githubusercontent.com/10521622/213140224-8576e28b-729b-4555-837a-f35f102d6e1a.png)
Sort by Name, note the header arrows:
![Screenshot 2023-01-18 at 09 53 01](https://user-images.githubusercontent.com/10521622/213140219-91b3443f-9b55-4bf0-b80d-06d328614eeb.png)
Sorting is stable. First I sorted by "Elevation", descending. Row with "Test2" appears above "Aconcagua" - then I sorted by "Continent". "Test2" still appears above "Aconcagua".
![Screenshot 2023-01-18 at 09 53 34](https://user-images.githubusercontent.com/10521622/213140213-041a368d-2b37-40cf-a930-dc75712a05d4.png)

