### PR TITLE
PACT-710 Ensure covering date and start/end date validation is aligned

### DIFF
--- a/app/uk/gov/nationalarchives/omega/editorial/services/CoveringDateError.scala
+++ b/app/uk/gov/nationalarchives/omega/editorial/services/CoveringDateError.scala
@@ -22,6 +22,7 @@
 package uk.gov.nationalarchives.omega.editorial.services
 
 import uk.gov.nationalarchives.omega.editorial.models.DateRange
+import java.time.LocalDate
 
 sealed abstract class CoveringDateError
 
@@ -30,6 +31,8 @@ object CoveringDateError {
   type Result[A] = Either[CoveringDateError, A]
 
   final case object ParseError extends CoveringDateError
+  final case class DateTooFarInFuture(date: LocalDate) extends CoveringDateError
+  final case class DateTooFarInPast(date: LocalDate) extends CoveringDateError
   final case class InvalidRange(range: DateRange) extends CoveringDateError
   final case class MultipleErrors(errs: List[CoveringDateError]) extends CoveringDateError
 

--- a/app/uk/gov/nationalarchives/omega/editorial/support/DateParser.scala
+++ b/app/uk/gov/nationalarchives/omega/editorial/support/DateParser.scala
@@ -45,7 +45,7 @@ object DateParser {
 
   private val partDelimiter = "/"
 
-  private val dateTimeFormatter =
+  val dateTimeFormatter =
     DateTimeFormatter
       .ofPattern(s"d${partDelimiter}M${partDelimiter}y")
       .withLocale(Locale.UK)

--- a/test/services/CoveringDateCalculatorSpec.scala
+++ b/test/services/CoveringDateCalculatorSpec.scala
@@ -59,7 +59,7 @@ class CoveringDateCalculatorSpec extends BaseSpec with TableDrivenPropertyChecks
       ),
       "1582 Oct 11"               -> defineTestCoveringDate("1582 Oct 11" -> "1582 Oct 11"),
       "1582 Oct 11 - 1582 Nov 29" -> defineTestCoveringDate("1582 Oct 11" -> "1582 Nov 29"),
-      "1 - 2023"                  -> defineTestCoveringDate("1 Jan 1" -> s"${LocalDate.now().getYear()} Dec 31"),
+      "1 - 2023"                  -> defineTestCoveringDate("1 Jan 1" -> s"${LocalDate.now().getYear} Dec 31"),
       // Dates related to the switchover from the Julian to the Gregorian calendar.
       "1752 Aug"                  -> defineTestCoveringDate("1752 Aug 1" -> "1752 Aug 31"),
       "1752 Aug 1–1752 Aug 2"     -> defineTestCoveringDate("1752 Aug 1" -> "1752 Aug 2"),
@@ -99,7 +99,7 @@ class CoveringDateCalculatorSpec extends BaseSpec with TableDrivenPropertyChecks
       "01 Oct 1305"                           -> ParseError,
       "Mon 1 Oct 1330"                        -> ParseError,
       "0 - 2023"                              -> DateTooFarInPast(LocalDate.of(0, 1, 1)),
-      s"1 - ${LocalDate.now().getYear() + 1}" -> DateTooFarInFuture(LocalDate.of(LocalDate.now().getYear + 1, 12, 31)),
+      s"1 - ${LocalDate.now().getYear + 1}" -> DateTooFarInFuture(LocalDate.of(LocalDate.now().getYear + 1, 12, 31)),
       "1999 - 1305" -> InvalidRange(DateRange(LocalDate.of(1999, 1, 1), LocalDate.of(1305, 12, 31))),
       "1999 - 1305; 2000 Feb 3 - 1306 Nov 30" -> MultipleErrors(
         List(

--- a/test/services/CoveringDateCalculatorSpec.scala
+++ b/test/services/CoveringDateCalculatorSpec.scala
@@ -27,6 +27,7 @@ import support.CommonMatchers.{ failToParseAs, parseSuccessfullyAs }
 import uk.gov.nationalarchives.omega.editorial.models.DateRange
 import uk.gov.nationalarchives.omega.editorial.services.CoveringDateCalculator
 import uk.gov.nationalarchives.omega.editorial.services.CoveringDateError._
+import uk.gov.nationalarchives.omega.editorial.support.DateParser
 
 import java.time._
 import java.time.format.DateTimeFormatter
@@ -58,6 +59,7 @@ class CoveringDateCalculatorSpec extends BaseSpec with TableDrivenPropertyChecks
       ),
       "1582 Oct 11"               -> defineTestCoveringDate("1582 Oct 11" -> "1582 Oct 11"),
       "1582 Oct 11 - 1582 Nov 29" -> defineTestCoveringDate("1582 Oct 11" -> "1582 Nov 29"),
+      "1 - 2023"                  -> defineTestCoveringDate("1 Jan 1" -> "2023 Dec 31"),
       // Dates related to the switchover from the Julian to the Gregorian calendar.
       "1752 Aug"                  -> defineTestCoveringDate("1752 Aug 1" -> "1752 Aug 31"),
       "1752 Aug 1–1752 Aug 2"     -> defineTestCoveringDate("1752 Aug 1" -> "1752 Aug 2"),
@@ -75,6 +77,19 @@ class CoveringDateCalculatorSpec extends BaseSpec with TableDrivenPropertyChecks
       }
     }
 
+    forAll(validScenarioTestTable) { (input, _) =>
+      s"""successfully calculated $input date range should also parse as a date"""" in {
+        val Right(dateRanges) = CoveringDateCalculator.getStartAndEndDates(input)
+        dateRanges.foreach { case DateRange(start, end) =>
+          val startStringDate = start.format(DateParser.dateTimeFormatter)
+          DateParser.parse(startStringDate) mustBe Some(start)
+
+          val endStringDate = end.format(DateParser.dateTimeFormatter)
+          DateParser.parse(endStringDate) mustBe Some(end)
+        }
+      }
+    }
+
     // TODO: Right now we don't check parse errors
     val invalidScenarioTestTable = Tables.Table(
       "date input"      -> "parse error",
@@ -83,11 +98,19 @@ class CoveringDateCalculatorSpec extends BaseSpec with TableDrivenPropertyChecks
       "Temp Edw I"      -> ParseError,
       "01 Oct 1305"     -> ParseError,
       "Mon 1 Oct 1330"  -> ParseError,
+      "0 - 2023"        -> DateTooFarInPast(LocalDate.of(0, 1, 1)),
+      "1 - 2024"        -> DateTooFarInFuture(LocalDate.of(2024, 12, 31)),
       "1999 - 1305"     -> InvalidRange(DateRange(LocalDate.of(1999, 1, 1), LocalDate.of(1305, 12, 31))),
       "1999 - 1305; 2000 Feb 3 - 1306 Nov 30" -> MultipleErrors(
         List(
           InvalidRange(DateRange(LocalDate.of(1999, 1, 1), LocalDate.of(1305, 12, 31))),
           InvalidRange(DateRange(LocalDate.of(2000, 2, 3), LocalDate.of(1306, 11, 30)))
+        )
+      ),
+      "1999 - 1305; 0 Feb 3 - 1306 Nov 30" -> MultipleErrors(
+        List(
+          InvalidRange(DateRange(LocalDate.of(1999, 1, 1), LocalDate.of(1305, 12, 31))),
+          DateTooFarInPast(LocalDate.of(0, 2, 3))
         )
       )
     )

--- a/test/services/CoveringDateCalculatorSpec.scala
+++ b/test/services/CoveringDateCalculatorSpec.scala
@@ -59,7 +59,7 @@ class CoveringDateCalculatorSpec extends BaseSpec with TableDrivenPropertyChecks
       ),
       "1582 Oct 11"               -> defineTestCoveringDate("1582 Oct 11" -> "1582 Oct 11"),
       "1582 Oct 11 - 1582 Nov 29" -> defineTestCoveringDate("1582 Oct 11" -> "1582 Nov 29"),
-      "1 - 2023"                  -> defineTestCoveringDate("1 Jan 1" -> "2023 Dec 31"),
+      "1 - 2023"                  -> defineTestCoveringDate("1 Jan 1" -> s"${LocalDate.now().getYear()} Dec 31"),
       // Dates related to the switchover from the Julian to the Gregorian calendar.
       "1752 Aug"                  -> defineTestCoveringDate("1752 Aug 1" -> "1752 Aug 31"),
       "1752 Aug 1–1752 Aug 2"     -> defineTestCoveringDate("1752 Aug 1" -> "1752 Aug 2"),
@@ -92,15 +92,15 @@ class CoveringDateCalculatorSpec extends BaseSpec with TableDrivenPropertyChecks
 
     // TODO: Right now we don't check parse errors
     val invalidScenarioTestTable = Tables.Table(
-      "date input"      -> "parse error",
-      "1270s"           -> ParseError,
-      "1305 Sept - Oct" -> ParseError,
-      "Temp Edw I"      -> ParseError,
-      "01 Oct 1305"     -> ParseError,
-      "Mon 1 Oct 1330"  -> ParseError,
-      "0 - 2023"        -> DateTooFarInPast(LocalDate.of(0, 1, 1)),
-      "1 - 2024"        -> DateTooFarInFuture(LocalDate.of(2024, 12, 31)),
-      "1999 - 1305"     -> InvalidRange(DateRange(LocalDate.of(1999, 1, 1), LocalDate.of(1305, 12, 31))),
+      "date input"                            -> "parse error",
+      "1270s"                                 -> ParseError,
+      "1305 Sept - Oct"                       -> ParseError,
+      "Temp Edw I"                            -> ParseError,
+      "01 Oct 1305"                           -> ParseError,
+      "Mon 1 Oct 1330"                        -> ParseError,
+      "0 - 2023"                              -> DateTooFarInPast(LocalDate.of(0, 1, 1)),
+      s"1 - ${LocalDate.now().getYear() + 1}" -> DateTooFarInFuture(LocalDate.of(LocalDate.now().getYear + 1, 12, 31)),
+      "1999 - 1305" -> InvalidRange(DateRange(LocalDate.of(1999, 1, 1), LocalDate.of(1305, 12, 31))),
       "1999 - 1305; 2000 Feb 3 - 1306 Nov 30" -> MultipleErrors(
         List(
           InvalidRange(DateRange(LocalDate.of(1999, 1, 1), LocalDate.of(1305, 12, 31))),


### PR DESCRIPTION
Examples of extra date validation:
<img width="789" alt="Screenshot 2023-02-03 at 09 34 26" src="https://user-images.githubusercontent.com/10521622/216565476-94c46c38-96f8-470f-98f4-0785fe382f61.png">
<img width="423" alt="Screenshot 2023-02-03 at 09 35 17" src="https://user-images.githubusercontent.com/10521622/216565463-610fd0f4-5c19-4604-a910-4c91b7df6da3.png">
<img width="438" alt="Screenshot 2023-02-03 at 09 35 06" src="https://user-images.githubusercontent.com/10521622/216565469-007c47ce-5e7b-4063-b1ab-486546d77bdc.png">

